### PR TITLE
pledger: fix edge case in `-l`/`--last` date handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "env_logger",
  "lazy_static",
  "log",
+ "num-traits",
  "phf",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = "3.0.0-beta.2"
 env_logger = "0.8"
 lazy_static = "1.4.0"
 log = "0.4"
+num-traits = "0.2"
 phf = { version = "0.8.0", features = ["macros"] }
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
The previous behavior used `Duration::weeks(4)` to calculate
the previous month, which wouldn't work on days in the month
beyond 28 (i.e., exactly 4 weeks).

The new approach fixes this by retrieving the previous month
symbolically and substituting it into the time. This should work
on all days of the month.